### PR TITLE
feat: add type definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.3",
   "description": "Feathers debugger service (For feathers debugger chrome extension)",
   "main": "src/index.js",
+  "types": "types",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -12,11 +12,11 @@ export interface DebuggerServiceOptions {
   /**
    * Whether to expose UI on publicUrl (default is false) and debug without chrome extension
    */
-  ui: boolean;
+  ui?: boolean;
   /**
    * If UI is exposed, define custom url for debugger (default is /debugger)
    */
-  publicUrl: string;
+  publicUrl?: string;
 }
 
 declare const debuggerService: (options?: DebuggerServiceOptions) => (app: Application) => void;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,41 @@
+import { Application, HookContext } from '@feathersjs/feathers';
+
+export interface DebuggerServiceOptions {
+  /**
+   * Expire item in storage after x seconds (default is 900)
+   */
+  expireAfterSeconds?: number;
+  /**
+   * Define filename if want to persist data to file (uses feathers-nedb)
+   */
+  filename?: string;
+  /**
+   * Whether to expose UI on publicUrl (default is false) and debug without chrome extension
+   */
+  ui: boolean;
+  /**
+   * If UI is exposed, define custom url for debugger (default is /debugger)
+   */
+  publicUrl: string;
+}
+
+declare const debuggerService: (options?: DebuggerServiceOptions) => (app: Application) => void;
+
+export interface TraceHookOptions {
+  /**
+   * Captures hook.params (default is false)
+   */
+  captureParams?: boolean;
+  /**
+   * Captures hook.result (default is false)
+   */
+  captureResult?: boolean;
+  /**
+   * Captures hook.params.query (default is false)
+   */
+  captureQuery?: boolean;
+}
+
+export const trace: (options?: TraceHookOptions) => (context: HookContext) => Promise<HookContext>;
+
+export default debuggerService;


### PR DESCRIPTION
Added type definition for this project, closes #6 

I have tested with ts/js project, and both looking fine. As this my first time adding for type definition, I hope I didn't miss out anything.

If this does gets accepted, do consider adding `topic` and `label` for [hacktoberfest](https://hacktoberfest.digitalocean.com/hacktoberfest-update) so it counts towards the contribution